### PR TITLE
Allow screenshot of only a selection. Add some options to customise screenshot

### DIFF
--- a/lib/capturer.js
+++ b/lib/capturer.js
@@ -60,6 +60,10 @@ export default class Capturer {
             timeoutReached = true;
         }, 1000);
 
+        if (!atom.config.get('screenshot.showWrapGuide')) {
+          this.hideWrapGuide(editor);
+        }
+
         let tryCapture = setInterval(() => {
 
             // not yet at the required position?
@@ -95,19 +99,36 @@ export default class Capturer {
             }
             let lastBounds = getLineBounds(last);
 
+            const includeLineNumbersAndGutter = atom.config.get('screenshot.includeLineNumbersAndGutter')
+
             // perform capture
             window.capturePage({
-                x: Math.ceil(bounds.left),
+                x: Math.ceil(includeLineNumbersAndGutter ? bounds.left : lastBounds.left),
                 y: Math.ceil(startBounds.top),
-                width: Math.floor(bounds.width - scrollbarOffset),
+                width: Math.floor(
+                  includeLineNumbersAndGutter ? bounds.width - scrollbarOffset : lastBounds.width),
                 height: Math.floor(lastBounds.bottom - startBounds.top),
             }, (img) => {
+                if (!atom.config.get('screenshot.showWrapGuide')) {
+                    this.showWrapGuide(editor);
+                }
                 // return result
                 cb(null, new CaptureResult(img, start, last));
             });
 
+
         }, 50);
 
+    }
+
+    hideWrapGuide(editor) {
+      const wrapGuide = editor.element.querySelector('.wrap-guide')
+      wrapGuide.style.visibility = 'hidden'
+    }
+
+    showWrapGuide(editor) {
+      const wrapGuide = editor.element.querySelector('.wrap-guide')
+      wrapGuide.style.visibility = 'inherit'
     }
 
 }

--- a/lib/screenshot.js
+++ b/lib/screenshot.js
@@ -27,6 +27,17 @@ export default {
         this.subscriptions.dispose();
     },
 
+    getScreenshotRange(editor) {
+      let range = editor.getSelectedBufferRanges().filter((range) => !range.isEmpty())
+      if (range.length === 0) {
+        range = editor.getBuffer().getRange()
+      } else {
+        // Only support the first range in the case of a multiselect
+        range = range[0]
+      }
+      return {start: range.start.row, end: range.end.row}
+    },
+
     takeScreenshot() {
 
         const window = remote.getCurrentWindow();
@@ -38,6 +49,10 @@ export default {
             });
             return;
         }
+
+        const screenshotRange = this.getScreenshotRange(editor)
+        const origin = editor.getCursorScreenPosition()
+        editor.setSelectedBufferRanges([origin, origin])
 
         // obtain default save path
         let basePath = os.homedir();
@@ -63,7 +78,7 @@ export default {
             if (!filename) return;
 
             // perform capture and save result
-            this.capturer.captureAll(window, editor, (captureErr, result) => {
+            this.capturer.captureRange(window, editor, screenshotRange, (captureErr, result) => {
                 // error handling
                 if (captureErr) {
                     atom.notifications.addError("Capture error", {
@@ -86,6 +101,10 @@ export default {
                     atom.notifications.addSuccess("Screenshot saved", {
                         detail: filename,
                     });
+
+                    if (atom.config.get('screenshot.openImage')) {
+                      atom.workspace.open(filename, {split: 'right'});
+                    }
                 });
             });
         });

--- a/package.json
+++ b/package.json
@@ -17,5 +17,22 @@
   },
   "dependencies": {
     "merge-images": "^1.1.0"
+  },
+  "configSchema": {
+    "openImage": {
+      "type": "boolean",
+      "default": false,
+      "description": "When enabled the screenshot will be opened in Atom once created."
+    },
+    "includeLineNumbersAndGutter": {
+      "type": "boolean",
+      "default": true,
+      "description": "When enabled the screenshot includes the gutter and line numbers."
+    },
+    "showWrapGuide": {
+      "type": "boolean",
+      "default": true,
+      "description": "When enabled the screenshot includes the wrap guide."
+    }
   }
 }


### PR DESCRIPTION
* If some code is selected when the screenshot is taken, only those lines are included
* Option to hide the wrap guide
* Option to hide the gutter/line numbers
* Option to open the image in atom


I can split the changes into separate PRs if you'd prefer.