### PR TITLE
docs(readme): Add note about archiving the repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 - 2020 Fabian Meyer
+Copyright (c) 2018 - 2022 Fabian Meyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![CI](https://github.com/meyfa/atom-screenshot/actions/workflows/main.yml/badge.svg)](https://github.com/meyfa/atom-screenshot/actions/workflows/main.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a8715072f334495f9370/maintainability)](https://codeclimate.com/github/meyfa/atom-screenshot/maintainability)
 
+| :warning: | Atom has been discontinued by GitHub[^1]. Since this project no longer serves a purpose, it won't be developed further, and has been archived. |
+|-|:----|
+
+[^1]: [Sunsetting Atom | The GitHub Blog (2022-06-08)](https://github.blog/2022-06-08-sunsetting-atom/)
+
 With this package, you can take a screenshot of your code as it is shown in
 Atom. With syntax highlighting and line numbers, but without any menus or
 toolbars.


### PR DESCRIPTION
Since Atom won't be supported further, atom-screenshot is being archived.